### PR TITLE
Update adafruit_mcp9808.py

### DIFF
--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -96,7 +96,7 @@ class MCP9808:
         self.buf[1] = self.buf[1] & 0x1f
         if self.buf[1] & 0x10 == 0x10:
             self.buf[1] = self.buf[1] & 0x0f
-            return 256 - (self.buf[1] * 16 + self.buf[2] / 16.0)
+            return (self.buf[1] * 16 + self.buf[2] / 16.0) - 256
         else:
             return self.buf[1] * 16 + self.buf[2] / 16.0
 


### PR DESCRIPTION
This change corrects an error in the temperature function that causes it not to return negative values for the temperature when below 0 degrees Celsius. I noticed the issue, but @jerryn and @cater figured out how to fix it.