### PR TITLE
adding methods to setup critical/upper and lower temperatures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,15 +61,15 @@ Getting the temperature in Celsius is easy! First, import all of the pins from
 the board, board.I2C() for native I2C communication and the thermometer library
 itself.
 
-.. code-block:: python
+.. code-block:: python3
 
-  from board import *
+  import board
   import adafruit_mcp9808
 
 Next, initialize the I2C bus in a with statement so it always gets shut down ok.
 Then, construct the thermometer class:
 
-.. code-block:: python
+.. code-block:: python3
 
   # Do one reading
   with i2c = board.I2C() as i2c:

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -113,7 +113,7 @@ class MCP9808:
     set critical temperature. False Otherwise"""
 
     above_upper = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)
-    """True when the temperature is above than the currently
+    """True when the temperature is above the currently
     set high temperature. False Otherwise"""
 
     below_lt = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -108,7 +108,7 @@ class MCP9808:
     """
 
     _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=2)
-    above_ct = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
+    above_critical = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
     """True when the temperature is above than the currently
     set critical temperature. False Otherwise"""
 

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -112,7 +112,7 @@ class MCP9808:
     """True when the temperature is above than the currently
     set critical temperature. False Otherwise"""
 
-    above_ut = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)
+    above_upper = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)
     """True when the temperature is above than the currently
     set high temperature. False Otherwise"""
 

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -109,8 +109,16 @@ class MCP9808:
 
     _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=2)
     above_ct = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
+    """True when the temperature is higher than the currently
+    set critical temperature. False Otherwise"""
+
     above_ut = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)
+    """True when the temperature is higher than the currently
+    set high temperature. False Otherwise"""
+
     below_lt = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)
+    """True when the temperature is lower than the currently
+    set lower temperature. False Otherwise"""
 
     def __init__(self, i2c_bus, address=_MCP9808_DEFAULT_ADDRESS):
         self.i2c_device = I2CDevice(i2c_bus, address)

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -117,7 +117,7 @@ class MCP9808:
     set high temperature. False Otherwise"""
 
     below_lt = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)
-    """True when the temperature is below than the currently
+    """True when the temperature is below the currently
     set lower temperature. False Otherwise"""
 
     def __init__(self, i2c_bus, address=_MCP9808_DEFAULT_ADDRESS):

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -116,7 +116,7 @@ class MCP9808:
     """True when the temperature is above the currently
     set high temperature. False Otherwise"""
 
-    below_lt = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)
+    below_lower = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)
     """True when the temperature is below the currently
     set lower temperature. False Otherwise"""
 

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -109,7 +109,7 @@ class MCP9808:
 
     _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=2)
     above_critical = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
-    """True when the temperature is above than the currently
+    """True when the temperature is above the currently
     set critical temperature. False Otherwise"""
 
     above_upper = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -109,15 +109,15 @@ class MCP9808:
 
     _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=2)
     above_ct = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
-    """True when the temperature is higher than the currently
+    """True when the temperature is above than the currently
     set critical temperature. False Otherwise"""
 
     above_ut = ROBit(_MCP9808_REG__TEMP, 6, register_width=1)
-    """True when the temperature is higher than the currently
+    """True when the temperature is above than the currently
     set high temperature. False Otherwise"""
 
     below_lt = ROBit(_MCP9808_REG__TEMP, 5, register_width=1)
-    """True when the temperature is lower than the currently
+    """True when the temperature is below than the currently
     set lower temperature. False Otherwise"""
 
     def __init__(self, i2c_bus, address=_MCP9808_DEFAULT_ADDRESS):

--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -148,6 +148,7 @@ class MCP9808:
 
     @property
     def upper_temperature(self):
+        """Upper temperature property"""
         self.buf[0] = 0x02
         with self.i2c_device as i2c:
             i2c.write_then_readinto(self.buf, self.buf, out_end=1, in_start=1)
@@ -156,10 +157,12 @@ class MCP9808:
 
     @upper_temperature.setter
     def upper_temperature(self, temp):
+        """Setup Upper temperature"""
         self._limit_temperatures(temp, 0x02)
 
     @property
     def lower_temperature(self):
+        """Lower temperature property"""
         self.buf[0] = 0x03
         with self.i2c_device as i2c:
             i2c.write_then_readinto(self.buf, self.buf, out_end=1, in_start=1)
@@ -168,10 +171,12 @@ class MCP9808:
 
     @lower_temperature.setter
     def lower_temperature(self, temp):
+        """Setup Lower temperature"""
         self._limit_temperatures(temp, 0x03)
 
     @property
     def critical_temperature(self):
+        """Critical temperature property"""
         self.buf[0] = 0x04
         with self.i2c_device as i2c:
             i2c.write_then_readinto(self.buf, self.buf, out_end=1, in_start=1)
@@ -180,4 +185,5 @@ class MCP9808:
 
     @critical_temperature.setter
     def critical_temperature(self, temp):
+        """Setup Critical temperature"""
         self._limit_temperatures(temp, 0x04)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ intersphinx_mapping = {
         "https://circuitpython.readthedocs.io/projects/busdevice/en/latest/",
         None,
     ),
+    "Register": (
+        "https://circuitpython.readthedocs.io/projects/register/en/latest/",
+        None,
+    ),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,13 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/mcp9808_simpletest.py
     :caption: examples/mcp9808_simpletest.py
     :linenos:
+
+
+Temperature Limit test
+----------------------
+
+Show the MCP9808 to setup different temperature values
+
+.. literalinclude:: ../examples/mcp9808_temperature_limits.py
+    :caption: examples/mcp9808_temperature_limits.py
+    :linenos:

--- a/examples/mcp9808_simpletest.py
+++ b/examples/mcp9808_simpletest.py
@@ -14,7 +14,6 @@ mcp = adafruit_mcp9808.MCP9808(i2c)
 # Necessary when, for example, connecting A0 to VDD to make address=0x19
 # mcp = adafruit_mcp9808.MCP9808(i2c_bus, address=0x19)
 
-
 while True:
     tempC = mcp.temperature
     tempF = tempC * 9 / 5 + 32

--- a/examples/mcp9808_temperature_limits.py
+++ b/examples/mcp9808_temperature_limits.py
@@ -23,6 +23,10 @@ print(mcp.temperature)
 time.sleep(0.3)  # This is the time temperature conversion at maximum resolution
 
 # Showing temperature Limits
-print("Lower Temperature Limit:", mcp.below_lt)
-print("Upper Temperature Limit:", mcp.above_ut)
-print("Critical Temperature Limit:", mcp.above_ct)
+while True:
+    if mcp.below_lt:
+        print("too cold!")
+    if mcp.above_ut:
+        print("getting hot!")
+    if mcp.above_ct:
+        print("Above critical temp!")

--- a/examples/mcp9808_temperature_limits.py
+++ b/examples/mcp9808_temperature_limits.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2021 Jose David M.
+# SPDX-License-Identifier: MIT
+
+"""
+Show the MCP9808 to setup different temperature values
+"""
+
+import time
+import board
+import adafruit_mcp9808
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+mcp = adafruit_mcp9808.MCP9808(i2c)
+
+# Change the values according to the desired values
+print("Setting Temperature Limits")
+mcp.upper_temperature = 23
+mcp.lower_temperature = 10
+mcp.critical_temperature = 100
+
+# To verify the limits we need to read the temperature value
+print(mcp.temperature)
+time.sleep(0.3)  # This is the time temperature conversion at maximum resolution
+
+# Showing temperature Limits
+print("Lower Temperature Limit:", mcp.below_lt)
+print("Upper Temperature Limit:", mcp.above_ut)
+print("Critical Temperature Limit:", mcp.above_ct)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+Adafruit-Blinka
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-register


### PR DESCRIPTION
Solves #27.

Trying to implement different functions according to issue 27. If this is already included after the board revision please feel free to close this PR. I could implement the other functions, just want to verify first.

Tested in
```pyhton
Adafruit CircuitPython 6.2.0-beta.3-188-g05ed179e1 on 2021-03-15; Adafruit Feather RP2040 with rp2040
```

This could be tested using the following script

```python
import time
import board
import adafruit_mcp9808

i2c = board.I2C()  # uses board.SCL and board.SDA
mcp = adafruit_mcp9808.MCP9808(i2c)

print("setting values, and reading temperature in between to clear the buffer")
mcp.upper_temperature = 89
print(mcp.temperature)
time.sleep(1)
mcp.lower_temperature = 55
print(mcp.temperature)
time.sleep(1)
mcp.critical_temperature = 100
print(mcp.temperature)
time.sleep(1)

print("checking that values are stored")
print("Lower Temperature Limit:", mcp.lower_temperature)
print("Upper Temperature Limit:", mcp.upper_temperature)
print("Critical Temperature Limit:", mcp.critical_temperature)

```