### PR TITLE
fix resolution register width

### DIFF
--- a/adafruit_mcp9808.py
+++ b/adafruit_mcp9808.py
@@ -115,7 +115,7 @@ class MCP9808:
 
     """
 
-    _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=2)
+    _MCP9808_REG_RESOLUTION_SET = RWBits(2, 0x08, 0, register_width=1)
     above_critical = ROBit(_MCP9808_REG__TEMP, 7, register_width=1)
     """True when the temperature is above the currently
     set critical temperature. False Otherwise"""


### PR DESCRIPTION
This implements the register width fix for the resolution setter as proposed by @dhalbert at:
- https://github.com/adafruit/Adafruit_CircuitPython_MCP9808/issues/41#issuecomment-3480984123

I've tested this by copying `adafruit_mcp9808.py` to `CIRCUITPY/lib/` in place of `adafruit_mcp9808.mpy`. When I did that, the following code ran without giving the exception mentioned in issue #41:

```python
Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Feather ESP32S3 No PSRAM with ESP32S3
>>> import board
>>> from adafruit_mcp9808 import MCP9808
>>> mcp98 = MCP9808(board.STEMMA_I2C())
>>> print("resolution is", mcp98.resolution)
resolution is 3
>>> mcp98.resolution = 1
>>> print("resolution is", mcp98.resolution)
resolution is 1
```

This is just a one character change, and I don't have pre-commit set up on this machine. So, I haven't run the pre-commit stuff.